### PR TITLE
adds bash -e and update clojure 1.9 path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 sudo apt-get clean
 sudo mv /var/lib/apt/lists/* /tmp
@@ -11,6 +11,8 @@ echo "================= Install clojure's build tool: leiningen ================
 sudo wget -nv https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
 sudo mv lein /usr/local/bin/lein
 sudo chmod a+x /usr/local/bin/lein
+
+apt-get install rlwrap
 
 for file in /u14cloall/version/*;
 do

--- a/version/1_3_0.sh
+++ b/version/1_3_0.sh
@@ -3,7 +3,7 @@
 # Install Clojure 1.3.0
 echo "================= Installing Clojure-1.3.0 ==================="
 sudo wget -nv http://repo1.maven.org/maven2/org/clojure/clojure/1.3.0/clojure-1.3.0.jar
-mkdir $HOME/lib && mv clojure-1.3.0.jar $HOME/lib/
+mkdir -p $HOME/lib && mv clojure-1.3.0.jar $HOME/lib/
 cat >/usr/local/bin/clj <<EOF
 #!/bin/bash
 if [[ $# -eq 0 ]]; then

--- a/version/1_4_0.sh
+++ b/version/1_4_0.sh
@@ -3,7 +3,7 @@
 # Install Clojure 1.4.0
 echo "================= Installing Clojure-1.4.0 ==================="
 sudo wget -nv http://central.maven.org/maven2/org/clojure/clojure/1.4.0/clojure-1.4.0.jar
-mkdir $HOME/lib && mv clojure-1.4.0.jar $HOME/lib/
+mkdir -p $HOME/lib && mv clojure-1.4.0.jar $HOME/lib/
 cat >/usr/local/bin/clj <<EOF
 #!/bin/bash
 if [[ $# -eq 0 ]]; then

--- a/version/1_5_1.sh
+++ b/version/1_5_1.sh
@@ -3,7 +3,7 @@
 # Install Clojure 1.5.1
 echo "================= Installing Clojure-1.5.1 ==================="
 sudo wget -nv http://central.maven.org/maven2/org/clojure/clojure/1.5.1/clojure-1.5.1.jar
-mkdir $HOME/lib && mv clojure-1.5.1.jar $HOME/lib/
+mkdir -p $HOME/lib && mv clojure-1.5.1.jar $HOME/lib/
 cat >/usr/local/bin/clj <<EOF
 #!/bin/bash
 if [[ $# -eq 0 ]]; then

--- a/version/1_6_0.sh
+++ b/version/1_6_0.sh
@@ -4,8 +4,9 @@
 echo "================= Installing Clojure-1.6.0 ==================="
 sudo wget -nv http://repo1.maven.org/maven2/org/clojure/clojure/1.6.0/clojure-1.6.0.zip
 sudo unzip clojure-1.6.0.zip
-mkdir $HOME/lib && cp clojure-1.6.0/clojure-1.6.0.jar $HOME/lib
+mkdir -p $HOME/lib && cp clojure-1.6.0/clojure-1.6.0.jar $HOME/lib
 sudo rm -rf clojure-1.6.0*
+
 cat >/usr/local/bin/clj <<EOF
 #!/bin/bash
 if [[ $# -eq 0 ]]; then

--- a/version/1_7_0.sh
+++ b/version/1_7_0.sh
@@ -4,8 +4,9 @@
 echo "================= Installing Clojure-1.7.0 ==================="
 sudo wget -nv http://repo1.maven.org/maven2/org/clojure/clojure/1.7.0/clojure-1.7.0.zip
 sudo unzip clojure-1.7.0.zip
-mkdir $HOME/lib && cp clojure-1.7.0/clojure-1.7.0.jar $HOME/lib
+mkdir -p $HOME/lib && cp clojure-1.7.0/clojure-1.7.0.jar $HOME/lib
 sudo rm -rf clojure-1.7.0*
+
 cat >/usr/local/bin/clj <<EOF
 #!/bin/bash
 if [[ $# -eq 0 ]]; then

--- a/version/1_8_0.sh
+++ b/version/1_8_0.sh
@@ -4,8 +4,9 @@
 echo "================= Installing Clojure-1.8.0 ==================="
 sudo wget -nv http://repo1.maven.org/maven2/org/clojure/clojure/1.8.0/clojure-1.8.0.zip
 sudo unzip clojure-1.8.0.zip
-mkdir $HOME/lib && cp clojure-1.8.0/clojure-1.8.0.jar $HOME/lib
+mkdir -p $HOME/lib && cp clojure-1.8.0/clojure-1.8.0.jar $HOME/lib
 sudo rm -rf clojure-1.8.0*
+
 cat >/usr/local/bin/clj <<EOF
 #!/bin/bash
 if [[ $# -eq 0 ]]; then

--- a/version/1_9_0.sh
+++ b/version/1_9_0.sh
@@ -6,13 +6,4 @@ curl -O https://download.clojure.org/install/linux-install-"$CLOJURE_VER".sh
 chmod +x linux-install-"$CLOJURE_VER".sh
 sudo ./linux-install-"$CLOJURE_VER".sh
 
-cat >/usr/local/bin/clj <<EOF
-#!/bin/bash
-if [[ $# -eq 0 ]]; then
-  java -server -cp $HOME/lib/clojure-"$CLOJURE_VER".jar clojure.main
-else
-  java -server -cp $HOME/lib/clojure-"$CLOJURE_VER".jar clojure.main $1 -- "$@"
-fi
-EOF
-sudo chmod a+x /usr/local/bin/clj
-
+clj -h


### PR DESCRIPTION
https://github.com/dry-dock/u14cloall/issues/12

the install script never had `-e` flag set, so we were not actually installing clojure jar file for 1.4 version onwards. 

```
ubuntu@ip-80-0-100-209:~/drydock/u14cloall$ sudo docker run -it niranjanhub/u14cloall:master bash
root@270d48139064:/# clj
Downloading: org/clojure/clojure/1.9.0/clojure-1.9.0.pom from https://repo1.maven.org/maven2/
Downloading: org/clojure/spec.alpha/0.1.143/spec.alpha-0.1.143.pom from https://repo1.maven.org/maven2/
Downloading: org/clojure/pom.contrib/0.2.2/pom.contrib-0.2.2.pom from https://repo1.maven.org/maven2/
Downloading: org/clojure/core.specs.alpha/0.1.24/core.specs.alpha-0.1.24.pom from https://repo1.maven.org/maven2/
Downloading: org/clojure/clojure/1.9.0/clojure-1.9.0.jar from https://repo1.maven.org/maven2/
Downloading: org/clojure/spec.alpha/0.1.143/spec.alpha-0.1.143.jar from https://repo1.maven.org/maven2/
Downloading: org/clojure/core.specs.alpha/0.1.24/core.specs.alpha-0.1.24.jar from https://repo1.maven.org/maven2/
Clojure 1.9.0
```